### PR TITLE
Delete project documents before removing project

### DIFF
--- a/actions/delete-project.ts
+++ b/actions/delete-project.ts
@@ -51,6 +51,16 @@ export async function deleteProject(prevState: State, formData: FormData) {
       );
     }
 
+    const { error: documentsError } = await supabase
+      .from('documents')
+      .delete()
+      .eq('project_id', projectId);
+
+    if (documentsError) {
+      console.error('Error deleting project documents:', documentsError);
+      throw new Error('Failed to delete project documents');
+    }
+
     const { error: filesError } = await supabase
       .from('files')
       .delete()


### PR DESCRIPTION
## Summary
- delete related documents before removing a project so foreign key constraints are respected

## Testing
- npm run build *(fails: unable to fetch Google Fonts in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dea27ac2688327977292b8c9d30aa1