### PR TITLE
Ensure OAuth callback stays on editor domain

### DIFF
--- a/app/auth/oauth/route.ts
+++ b/app/auth/oauth/route.ts
@@ -1,28 +1,21 @@
 import { NextResponse } from 'next/server';
-// The client you created from the Server-Side Auth instructions
+import { buildRedirectUrl } from '@/lib/auth/redirect';
 import { createClient } from '@/lib/supabase/server';
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get('code');
-  // If "next" is in param use it; ignore provider state to avoid mismatches
-  let next = searchParams.get('next') ?? '/';
-  if (!next.startsWith('/')) {
-    // if "next" is not a relative URL, use the default
-    next = '/';
-  }
+  const nextParam = searchParams.get('next') ?? '/';
+  const next = nextParam.startsWith('/') ? nextParam : '/';
 
   if (code) {
     const supabase = await createClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      const forwardedHost = request.headers.get('x-forwarded-host'); // original origin before load balancer
-      const isLocalEnv = process.env.NODE_ENV === 'development';
-      const dest = forwardedHost ? `https://${forwardedHost}${next}` : `${origin}${next}`;
-      return NextResponse.redirect(dest, { status: 303 });
+      const destination = buildRedirectUrl(request.headers, origin, next);
+      return NextResponse.redirect(destination, { status: 303 });
     }
   }
 
-  // return the user to an error page with instructions
   return NextResponse.redirect(`${origin}/auth/error`);
 }

--- a/lib/auth/__tests__/redirect.test.ts
+++ b/lib/auth/__tests__/redirect.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildRedirectUrl, resolveRedirectBase } from '../redirect';
+
+test('prefers the direct host header over forwarded host', () => {
+  const headers = new Headers({
+    host: 'ai-latex-editor.useoctree.com',
+    'x-forwarded-host': 'tools.useoctree.com',
+    'x-forwarded-proto': 'https',
+  });
+
+  const base = resolveRedirectBase(headers, new URL('https://ai-latex-editor.useoctree.com/auth/oauth'));
+  assert.equal(base.origin, 'https://ai-latex-editor.useoctree.com');
+
+  const redirect = buildRedirectUrl(headers, 'https://ai-latex-editor.useoctree.com', '/projects/123');
+  assert.equal(redirect, 'https://ai-latex-editor.useoctree.com/projects/123');
+});
+
+test('falls back to forwarded host when allow-listed', () => {
+  const headers = new Headers({
+    'x-forwarded-host': 'preview.ai-latex-editor.vercel.app',
+    'x-forwarded-proto': 'https',
+  });
+
+  const base = resolveRedirectBase(
+    headers,
+    new URL('https://ai-latex-editor.useoctree.com/auth/oauth'),
+    'preview.ai-latex-editor.vercel.app'
+  );
+  assert.equal(base.origin, 'https://preview.ai-latex-editor.vercel.app');
+
+  const redirect = buildRedirectUrl(
+    headers,
+    'https://ai-latex-editor.useoctree.com',
+    '/projects/123',
+    'preview.ai-latex-editor.vercel.app'
+  );
+  assert.equal(redirect, 'https://preview.ai-latex-editor.vercel.app/projects/123');
+});
+
+test('defaults to origin host when no candidate is allow-listed', () => {
+  const headers = new Headers({
+    host: 'internal.vercel.app',
+    'x-forwarded-host': 'example.com',
+    'x-forwarded-proto': 'https',
+  });
+
+  const base = resolveRedirectBase(headers, new URL('https://ai-latex-editor.useoctree.com/auth/oauth'));
+  assert.equal(base.origin, 'https://ai-latex-editor.useoctree.com');
+});

--- a/lib/auth/redirect.ts
+++ b/lib/auth/redirect.ts
@@ -1,0 +1,79 @@
+type HeaderRecord = Record<string, string>;
+
+function headersToRecord(headers: Headers | HeaderRecord): HeaderRecord {
+  if (headers instanceof Headers) {
+    const record: HeaderRecord = {};
+    headers.forEach((value, key) => {
+      record[key.toLowerCase()] = value;
+    });
+    return record;
+  }
+  const record: HeaderRecord = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === 'string') {
+      record[key.toLowerCase()] = value;
+    }
+  }
+  return record;
+}
+
+function parseHeaderList(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Resolve the host + protocol used for post-OAuth redirects.
+ *
+ * When the editor is launched from the Tools hub the request is proxied through
+ * `tools.useoctree.com`, which populates `x-forwarded-host` with the Tools domain.
+ * If we redirect to that forwarded host the browser stays on the Tools origin and
+ * the Supabase session cookie never reaches the editor domain. By preferring the
+ * actual request host we land back on the ai-latex-editor origin and the session
+ * becomes visible to the app.
+ */
+export function resolveRedirectBase(
+  headersInput: Headers | HeaderRecord,
+  origin: URL,
+  allowedHostsEnv = process.env.ALLOWED_REDIRECT_HOSTS
+): URL {
+  const headers = headersToRecord(headersInput);
+
+  const allowList = new Set<string>();
+  const fallbackHost = origin.host;
+  allowList.add(fallbackHost);
+
+  if (allowedHostsEnv) {
+    for (const host of allowedHostsEnv.split(',').map((value) => value.trim())) {
+      if (host) {
+        allowList.add(host);
+      }
+    }
+  }
+
+  const candidates = [
+    ...parseHeaderList(headers['host']),
+    ...parseHeaderList(headers['x-forwarded-host']),
+    origin.host,
+  ].filter(Boolean);
+
+  const host = candidates.find((candidate) => allowList.has(candidate)) ?? fallbackHost;
+
+  const protoCandidates = parseHeaderList(headers['x-forwarded-proto']);
+  const protocol = protoCandidates[0] ?? origin.protocol.replace(':', '');
+
+  return new URL(`${protocol}://${host}`);
+}
+
+export function buildRedirectUrl(
+  headers: Headers | HeaderRecord,
+  origin: string,
+  nextPath: string,
+  allowedHostsEnv = process.env.ALLOWED_REDIRECT_HOSTS
+): string {
+  const baseUrl = resolveRedirectBase(headers, new URL(origin), allowedHostsEnv);
+  return new URL(nextPath, baseUrl).toString();
+}


### PR DESCRIPTION
## Summary
- add a reusable helper to resolve the safe redirect origin, prioritising the request host and supporting an allow-list for forwarded hosts
- update the Supabase OAuth callback to use the helper so proxied launches from Tools land back on the editor domain with a valid session
- cover the redirect resolution logic with node:test cases documenting the Tools proxy scenario

## Testing
- npx tsc lib/auth/redirect.ts lib/auth/__tests__/redirect.test.ts --outDir .tmp-tests --module node16 --moduleResolution node16 --target es2022 --esModuleInterop
- node --test .tmp-tests/__tests__/redirect.test.js
- npm run build *(fails: cannot download Google Fonts in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df57b4c9208327afa11bac0bf5b566